### PR TITLE
Make BugsnagSettings pure

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -20,7 +20,6 @@ library:
     - aeson
     - bytestring
     - case-insensitive
-    - exceptions
     - http-client
     - http-client-tls
     - http-conduit
@@ -41,7 +40,6 @@ tests:
     dependencies:
       - hspec
       - bugsnag-reporter
-      - exceptions
   doctest:
     main: DocTest.hs
     source-dirs: .

--- a/src/Network/Bugsnag/Catch.hs
+++ b/src/Network/Bugsnag/Catch.hs
@@ -3,15 +3,13 @@ module Network.Bugsnag.Catch
     ( catchBugsnag
     ) where
 
-import Control.Exception hiding (Handler, catch)
-import Control.Monad.Catch
-import Control.Monad.IO.Class (MonadIO)
+import Control.Exception
 import Network.Bugsnag.Exception
 import Network.Bugsnag.Notify
 import Network.Bugsnag.Settings
 
 -- | Catch any exception, notify bugsnag and re-throw it
-catchBugsnag :: (MonadIO m, MonadCatch m) => m a -> BugsnagSettings m -> m a
+catchBugsnag :: IO a -> BugsnagSettings -> IO a
 catchBugsnag io settings = io `catch` \ex -> do
     notifyBugsnag settings $ bugsnagExceptionFromSomeException ex
-    throwM $ toException ex
+    throw $ toException ex

--- a/test/Network/BugsnagSpec.hs
+++ b/test/Network/BugsnagSpec.hs
@@ -9,11 +9,10 @@ module Network.BugsnagSpec
 import Test.Hspec
 
 import Control.Exception
-import Control.Monad.Catch (throwM)
 import Network.Bugsnag
 
 brokenFunctionIO :: IO a
-brokenFunctionIO = throwM $ bugsnagException
+brokenFunctionIO = throw $ bugsnagException
     "IOException" "Something exploded" [$(currentStackFrame) "brokenFunctionIO"]
 
 brokenFunction :: HasCallStack => a
@@ -38,7 +37,7 @@ spec = do
 
             let frame = head $ beStacktrace ex
             bsfFile frame `shouldBe` "test/Network/BugsnagSpec.hs"
-            bsfLineNumber frame `shouldBe` 17
+            bsfLineNumber frame `shouldBe` 16
             bsfColumnNumber frame `shouldBe` Just 43
             bsfMethod frame `shouldBe` "brokenFunctionIO"
             bsfInProject frame `shouldBe` Just True
@@ -60,14 +59,14 @@ spec = do
 
             let frame = head $ beStacktrace ex
             bsfFile frame `shouldBe` "test/Network/BugsnagSpec.hs"
-            bsfLineNumber frame `shouldBe` 24
+            bsfLineNumber frame `shouldBe` 23
             bsfColumnNumber frame `shouldBe` Just 15
             bsfMethod frame `shouldBe` "error"
 
             map bsfMethod (beStacktrace ex)
                 `shouldBe` ["error", "sillyHead", "brokenFunction"]
 
-disabledSettings :: IO (BugsnagSettings IO)
+disabledSettings :: IO BugsnagSettings
 disabledSettings = do
     settings <- newBugsnagSettings ""
     pure $ settings { bsNotifyReleaseStages = [] }


### PR DESCRIPTION
This means that we can't rely on application state in the global
before-notify. For example:

    , bsBeforeNotify = \event -> do
        request <- waiRequest
        pure $ updateEventFromRequest request event

    -- Later
    notifyBugsnag settings ex

Instead, we can only do pure things there:

    , bsBeforeNotify = setWarning

And need to use notifyBugsnagWith for other stuff:

    errorHandler (InternalError msg) = do
        request <- waiRequest

        let ex = bugsnagExceptionFromErrorMessage msg
            beforeNotify = updateEventFromRequest request

        notifyBugsnagWith beforeNotify settings ex

This may be perfectly acceptable and worth the simplification. The only
real downside is that we can't use catchBugsnag as-is if we want to be
able to inject a context-aware before-notify. Of course, we could
implement a catchBugsnagWith if that becomes problematic.